### PR TITLE
Overflow menu a11y

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 **/node_modules
 vendor/
+dist/

--- a/components/menu/OverflowMenu/html/base.html
+++ b/components/menu/OverflowMenu/html/base.html
@@ -5,5 +5,5 @@
         </svg>
     </button>
 
-    <div className="overflow-menu__actions"></div>
+    <div role="presentation" className="overflow-menu__actions"></div>
 </div>

--- a/components/menu/OverflowMenu/html/withChildren.html
+++ b/components/menu/OverflowMenu/html/withChildren.html
@@ -5,7 +5,7 @@
         </svg>
     </button>
 
-    <div class="overflow-menu__actions">
+    <div role="presentation" class="overflow-menu__actions">
         <p>SAVED ON: 05/30/18<br>EDITED BY: LOREM IPSUM</p>
         <button type="button" class="btn btn--light btn--uppercase btn--full-width">My First Button</button>
         <button type="button" class="btn btn--light btn--uppercase btn--full-width">My Second Button</button>

--- a/components/menu/OverflowMenu/react.js
+++ b/components/menu/OverflowMenu/react.js
@@ -44,7 +44,7 @@ export class OverflowMenu extends Component {
 
         {displayOverflowMenuActions
           && (
-          <div className={cx('overflow-menu__actions')} onClick={e => this.checkToCloseOverflowMenu(e)}>
+          <div role="presentation" className={cx('overflow-menu__actions')} onClick={e => this.checkToCloseOverflowMenu(e)} onKeyPress={e => this.checkToCloseOverflowMenu(e)}>
             {children}
           </div>
           )


### PR DESCRIPTION
Fix accessibility linting errors within OverflowMenu.

- [no-static-element-interactions](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md)
- [click-events-have-key-events](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/click-events-have-key-events.md)

This also resolves the failed travis status.