### PR TITLE
MXP-146 Add in a prop to allow for center align or right align of tex…

### DIFF
--- a/components/TextField/react.js
+++ b/components/TextField/react.js
@@ -21,6 +21,7 @@ const TextField = ({
   value,
   variant,
   removeMargin,
+  align,
 }) => {
   const [isActive, setActive] = useState(false)
   const Label = label ? 'label' : 'div'
@@ -46,7 +47,10 @@ const TextField = ({
       <div className={cx('text-field__label')}>{label}</div>
       <div className={cx('text-field__helper')}>{helper}</div>
       <input
-        className={cx('text-field__input')}
+        className={cx('text-field__input', {
+          'text-field__input--align-right': align === 'right',
+          'text-field__input--align-center': align === 'center',
+        })}
         type={type}
         placeholder={isActive || !label ? placeholder : ''}
         onKeyDown={onKeyDown}
@@ -84,6 +88,7 @@ TextField.propTypes = {
   type: PropTypes.oneOf(['text', 'number', 'email']),
   variant: PropTypes.oneOf(['dark', 'light']),
   removeMargin: PropTypes.bool,
+  align: PropTypes.oneOf(['left', 'center', 'right']),
 }
 
 TextField.defaultProps = {
@@ -99,4 +104,5 @@ TextField.defaultProps = {
   type: 'text',
   variant: 'dark',
   removeMargin: false,
+  align: 'left',
 }

--- a/components/TextField/stories.react.js
+++ b/components/TextField/stories.react.js
@@ -34,3 +34,28 @@ storiesOf('TextField', module)
       )
     }),
   )
+  .add(
+    'center',
+    withState({ value: '' })(({ store }) => {
+      const variant = select('Variant', { Light: 'light', Dark: 'dark' }, 'dark')
+      const label = text('Label', 'Label')
+      const error = boolean('Error State', false)
+      const helper = error ? 'Something is wrong.' : ''
+      const showTrailingIcon = boolean('Show Trailing Icon', true)
+      const trailingIcon = showTrailingIcon && mPhone
+      return (
+        <TextField
+          error={error}
+          helper={helper}
+          placeholder="Placeholder"
+          onBlur={value => console.log('onBlur called, value: ', value)}
+          onChange={value => store.set({ value })}
+          trailingIcon={trailingIcon}
+          value={store.state.value}
+          variant={variant}
+          removeMargin={false}
+          align={'center'}
+        />
+      )
+    }),
+  )

--- a/components/TextField/style.module.scss
+++ b/components/TextField/style.module.scss
@@ -23,6 +23,14 @@
     box-sizing: border-box;
     transition: box-shadow 200ms ease-in;
     width: 100%;
+
+    &--align-right {
+      text-align: right;
+    }
+
+    &--align-center {
+      text-align: center;
+    }
   }
 
   &--light &__input {


### PR DESCRIPTION
This adds a prop for the user to either center align or right align the text inside of the input textfield. As of now, nothing has been done for different scenarios on right alignment of the input field inside of the textfield. This is due to no use case atm.

The main reason for this update is to center the text, as it will be used for a MPrice update