### PR TITLE
Move styles to stylesheet that is imported once

### DIFF
--- a/styles/global.scss
+++ b/styles/global.scss
@@ -2,6 +2,15 @@
 
 @import url("https://cloud.typography.com/7038756/6738972/css/fonts.css");
 
+html {
+  box-sizing: border-box;
+}
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
 @import "index";
 @import "grid";
 

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,14 +1,5 @@
 /* index.scss - Variables and mixins ONLY. */
 
-html {
-  box-sizing: border-box;
-}
-*,
-*:before,
-*:after {
-  box-sizing: inherit;
-}
-
 @import "functions"; // Bootstrap grid dependency
 @import "config-variables";
 


### PR DESCRIPTION
Solves #83 

global is meant to be imported once for a project, whereas index is just to get the mixins/variables. This should remove a ton of duplicate CSS.