### PR TITLE
Allow TextField value to be null

### DIFF
--- a/components/TextField/react.js
+++ b/components/TextField/react.js
@@ -25,6 +25,7 @@ const TextField = ({
 }) => {
   const [isActive, setActive] = useState(false)
   const Label = label ? 'label' : 'div'
+  const fieldValue = (value || '').toString()
 
   const TrailingIcon = () => (
     <div
@@ -40,7 +41,7 @@ const TextField = ({
         'text-field--light': variant === 'light',
         'text-field--dark': variant === 'dark',
         'text-field--error': error,
-        'text-field--active': isActive || value.length,
+        'text-field--active': isActive || fieldValue.length,
         'text-field--no-margin': removeMargin,
       })}
     >
@@ -65,7 +66,7 @@ const TextField = ({
         }}
         onChange={event => onChange(event.target.value, event)}
         onClick={onClick}
-        value={value}
+        value={fieldValue}
       />
       <TrailingIcon />
     </Label>
@@ -84,7 +85,7 @@ TextField.propTypes = {
   label: PropTypes.string,
   onKeyDown: PropTypes.func,
   placeholder: PropTypes.string,
-  value: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   trailingIcon: PropTypes.string,
   type: PropTypes.oneOf(['text', 'number', 'email']),
   variant: PropTypes.oneOf(['dark', 'light']),
@@ -106,4 +107,5 @@ TextField.defaultProps = {
   variant: 'dark',
   removeMargin: false,
   align: 'left',
+  value: '',
 }

--- a/packages/external-ui-react/CHANGELOG.md
+++ b/packages/external-ui-react/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
 - `<TextField />` crashing when value is `null`
 

--- a/packages/external-ui-react/CHANGELOG.md
+++ b/packages/external-ui-react/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `<TextField />` crashing when value is `null`
+
 ## [2.10.1] - 2019-10-02
 
 ### Fixed

--- a/packages/external-ui-react/CHANGELOG.md
+++ b/packages/external-ui-react/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `<TextField />` crashing when value is `null`
+- `<TextField />` allows for `null` value
 
 ## [2.10.1] - 2019-10-02
 


### PR DESCRIPTION
Fixes https://github.com/masonitedoors/MDL/issues/85

In addition to allowing `null`, these changes also allow for number types to be used as values.