### PR TITLE
Update font weight for H1 and font family for Button

### DIFF
--- a/components/Button/style.module.scss
+++ b/components/Button/style.module.scss
@@ -5,6 +5,7 @@
   padding: 7px 15px;
   font-weight: 400;
   font-size: 14px;
+  font-family: $font-family;
   border: 1px solid transparent;
   border-radius: 2px;
   text-align: center;

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -11,7 +11,7 @@ $font-family: "Gotham SSm A", "Gotham SSm B", -apple-system, BlinkMacSystemFont,
   margin: 0 0 1rem;
   color: $color-limerick;
   font-family: $font-family;
-  font-weight: 500;
+  font-weight: 700;
   line-height: 1.33;
 }
 

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -3,8 +3,10 @@
 @import "index";
 @import "grid";
 
-html {
+html, body {
   box-sizing: border-box;
+  font-family: $font-family;
+  font-size: $base-font-size;
 }
 
 *,


### PR DESCRIPTION
The version of Gotham used originally is slightly different. When using the one from fonts.com, 500 was too thin and didn't represent bold.

User-agent sets the font-family for button tags, at least in Chrome. Added explicit font family.
