### PR TITLE
Add dismiss on Esc keyup to BackdropModal

### DIFF
--- a/components/ModalBackdrop/react.js
+++ b/components/ModalBackdrop/react.js
@@ -7,7 +7,12 @@ import styles from './style.module.scss'
 const cx = classNames.bind(styles)
 
 const ModalBackdrop = ({
-  children, className, onOutsideClick, show, style,
+  children,
+  className,
+  dismissOnEsc = true,
+  onOutsideClick,
+  show,
+  style,
 }) => {
   const [entered, setEntered] = useState(false)
   const backdropRef = useRef()
@@ -15,6 +20,12 @@ const ModalBackdrop = ({
   useEffect(() => {
     // Inner transition won't fire, if outer transition's `in` is already true.
     setEntered(show)
+
+    const dismissModal = event => ['Esc', 'Escape'].includes(event.key) && onOutsideClick()
+
+    dismissOnEsc && window.addEventListener('keyup', dismissModal)
+
+    return () => window.removeEventListener('keyup', dismissModal)
   }, [])
 
   return (

--- a/components/ModalBackdrop/react.stories.js
+++ b/components/ModalBackdrop/react.stories.js
@@ -10,9 +10,11 @@ storiesOf('ModalBackdrop', module)
   .add('default', () => {
     const [show, setShow] = useState(true)
 
+    const onOutsideClick = () => console.log('click') || setShow(false)
+
     return (
       <>
-        <ModalBackdrop onOutsideClick={() => console.log('click') || setShow(false)} show={show}>
+        <ModalBackdrop onOutsideClick={onOutsideClick} show={show}>
           <div>Content shows in center</div>
         </ModalBackdrop>
         <Button onClick={() => setShow(true)}>Show Modal</Button>

--- a/packages/external-ui-react/CHANGELOG.md
+++ b/packages/external-ui-react/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.38.0] - 2021-09-14
+
+### Added
+
+- Dismiss `Backdrop` on `Esc` keypress.
+
 ## [2.37.0] - 2021-05-19
 
 ### Added


### PR DESCRIPTION
I didn't want to rename onOutsideClick and make a breaking change, but Esc will now call the onOutsideClick function (which should be used to control the visibility or if it is rendered), since they will have the same effect 99% of the time.

Closes #132 
