### PR TITLE
Remove table styling from table element

### DIFF
--- a/components/Table/react.stories.js
+++ b/components/Table/react.stories.js
@@ -103,7 +103,7 @@ storiesOf('Table', module)
     </Table>
   ))
   .add('HTML (classless)', () => (
-    <table>
+    <table className={cx('table')}>
       <thead>
         <tr>
           <th>Heading</th>

--- a/components/Table/style.module.scss
+++ b/components/Table/style.module.scss
@@ -14,7 +14,6 @@ $cell-height: 49px;
   overflow: auto;
 }
 
-table,
 .table {
   position: relative;
   text-align: left;


### PR DESCRIPTION
As discussed, table is unstyled without the use of the .table CSS class