### PR TITLE
Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,24 @@
 # MDL - Masonite Design Language
 
-[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/) [![Build Status](https://travis-ci.org/masonitedoors/MDL.svg?branch=master)](https://travis-ci.org/masonitedoors/MDL)
+[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/) [![Build Status](https://travis-ci.org/masonitedoors/MDL.svg?branch=master)](https://travis-ci.org/masonitedoors/MDL) <a href="https://storybook.js.org/">
+<img src="https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg" alt="Maintained with Storybook" />
+</a>
 
-A monorepo for Masonite Design Language.
+A monorepo housing Masonite Design Language components and styles for development and reference.
 
-## Usage
+## Packages
 
-For usage information, please refer to each individual package's docs:
+### [@masonite/external-ui-react](packages/external-ui-react/README.md)
 
-- [@masonite/external-ui-react](packages/external-ui-react/README.md)
-- [@masonite/svg-icons](packages/svg-icons/README.md)
+Provides CSS, SCSS partials, and React components.
 
-## Deploying to npm
+### [@masonite/svg-icons](packages/svg-icons/README.md)
 
-Lerna handles the package.json version, the tags, and releases. However, each package may have their own additional steps. Follow the steps below for each package, then run `lerna publish`.
+All of the SVG icons.
 
-### @masonite/external-ui-react
+### [@masonite/tailwindcss](packages/tailwindcss/README.md)
 
-- Update the `CHANGELOG.md` in `packages/external-ui-react`. If there is an `[Unreleased]` block, change that to the next version following semver.
-- Build the package `npm run build-package:external-ui-react`
-
-### @masonite/svg-icons
-
-- Have the MIcons repo cloned in vendors. Clone the `Masonitedoors/MDL` repo with `git clone --recurse-submodules -j8` to get it.
-- Update the `CHANGELOG.md` in `packages/svg-icons`. If there is an `[Unreleased]` block, change that to the next version following semver.
-- Build the package `npm run build-package:svg-icons`
+Supplement the base CSS with MDL [Tailwind](https://tailwindcss.com/) utility classes.
 
 ## Contributing
 

--- a/packages/external-ui-react/README.md
+++ b/packages/external-ui-react/README.md
@@ -1,112 +1,51 @@
 # @masonite/external-ui-react
 
+MDL styles and React components for development. See them in action in [Storybook](https://masonitedoors.github.io/MDL).
+
 ## Install
 
 ```shell
-npm install --save @masonite/external-ui-react
+npm i @masonite/external-ui-react
 ```
 
 ## Usage
 
-Import a component as shown below and you're good to go.
+### CSS
+
+Add MDL CSS using SCSS found in the `/styles` directory. There are 2 main files to choose from: **index.scss** and **global.scss**. Index provides variables and mixins only. You can safely use this any CSS file. Global adds styling to `h1`-`h6`, `p`, and other element tags, as well as the variables.
+
+#### Customize
+
+Alternatively, you can modify the SCSS by defining the variables found in [\_config-variables.scss](https://github.com/masonitedoors/MDL/blob/master/styles/_config-variables.scss) before importing **index.scss**.
+
+### Import Examples
+
+#### ES6
 
 ```js
-import { Button } from "@masonite/external-ui-react";
+import '@masonite/external-ui-react/dist/styles/index.scss'
 ```
 
-## Components
+#### SCSS file
 
-Props noted with an asterisk are required. Not always by necessity, but by lack of defaults or fallback options. These components can be improved.
+```css
+// This is using webpack. How you access node_modules may differ.
+@import '~@masonite/external-ui-react/dist/styles/index.scss';
+```
 
-### cards/BlogCard
+### React components
 
-| Prop    | Default    | Accepted Values |
-| ------- | ---------- | --------------- |
-| onClick | `() => {}` | function        |
-| title   | ''         | string          |
-| content | null       | string          |
+Import a component as shown below and you're good to go. See the list of available components on [Storybook](https://masonitedoors.github.io/MDL) or check the [components](https://github.com/masonitedoors/MDL/tree/master/components) source folder.
 
-### cards/TrendCard
+```js
+import { Button } from '@masonite/external-ui-react'
+```
 
-| Prop    | Default    | Accepted Values |
-| ------- | ---------- | --------------- |
-| onClick | `() => {}` | function        |
-| title   | ''         | string          |
-| content | null       | string          |
+## Development
 
-### forms/Button
+Clone down `Masonitedoors/MDL`, install dependencies, and run `npm run storybook:react`.
 
-| Prop      | Default    | Accepted Values       |
-| --------- | ---------- | --------------------- |
-| disabled  | false      | boolean               |
-| fullWidth | false      | boolean               |
-| onClick   | `() => {}` | function              |
-| uppercase | boolean    | false                 |
-| size      | null       | null, 'small'         |
-| variant   | null       | null, 'light', 'dark' |
+### Deployment
 
-### forms/Checkbox
-
-| Prop     | Default   | Accepted Values | Description |
-| -------- | --------- | --------------- | ----------- |
-| onChange | undefined | function        |             |
-| checked  | false     | boolean         |             |
-
-### forms/FilterableSearch
-
-| Prop             | Default   | Accepted Values                                      | Description                                |
-| ---------------- | --------- | ---------------------------------------------------- | ------------------------------------------ |
-| buttonLabel      | 'Search'  | string                                               |                                            |
-| dropdownIcon     | 'chevron' | 'chevron', 'filter'                                  |                                            |
-| filterChoices    | ---       | { label: string, value: string, checked: boolean }[] |                                            |
-| onFilterChange\* | ---       | function                                             |                                            |
-| onInputChange    | undefined | function                                             |                                            |
-| onSubmit         | undefined | function                                             | Called when button is pressed or Enter key |
-| placeholder      | 'Search'  | string                                               |                                            |
-| value\*          | ---       | string                                               |                                            |
-
-### forms/TextField
-
-| Prop        | Default | Accepted Values | Description                   |
-| ----------- | ------- | --------------- | ----------------------------- |
-| error       | ---     | boolean         | Error state                   |
-| helper      | --      | string          | Text that appears below input |
-| label       | ---     | string          |                               |
-| onBlur      | --      | function        |                               |
-| onChange\*  | ---     | function        | Returns event                 |
-| placeholder | ---     | string          |                               |
-| value\*     | ---     | string          |                               |
-| variant\*   | ---     | 'dark', null    |                               |
-
-### forms/Toggle
-
-| Prop     | Default | Accepted Values | Description |
-| -------- | ------- | --------------- | ----------- |
-| checked  | false   | boolean         |             |
-| disabled | false   | boolean         |             |
-| onChange | null    | function        |             |
-
-### forms/RadioGroup
-
-| Prop          | Default | Accepted Values                       | Description |
-| ------------- | ------- | ------------------------------------- | ----------- |
-| choices\*     |         | `[{ label: String, value: String },]` |             |
-| checkedChoice | false   | string                                |             |
-| onChange\*    |         | function                              |             |
-| row           | false   | boolean                               |             |
-
-### menu/OverflowMenu
-
-| Prop     | Default | Accepted Values  | Description |
-| -------- | ------- | ---------------- | ----------- |
-| children | --      | function, string |             |
-
-### nav/Tabs
-
-Documentation incomplete.
-
-| Prop         | Default   | Accepted Values                           | Description                                     |
-| ------------ | --------- | ----------------------------------------- | ----------------------------------------------- |
-| activeTab\*  | undefined | number, string                            | Unique identifier                               |
-| onTabClick\* | undefined | function                                  | On tab click callback                           |
-| tabs         | Object[]  | `[{ id: number\|string, children: jsx }]` | Tabs use `{children}` for ultimate flexibility. |
+1. Update the `CHANGELOG.md` for the version you're releasing. If there is an `[Unreleased]` block, change that to the next version following semver.
+1. Build the package with `npm run build-package:external-ui-react` from the monorepo root, followed by `lerna publish`.

--- a/packages/svg-icons/README.md
+++ b/packages/svg-icons/README.md
@@ -11,11 +11,21 @@ npm install --save @masonite/svg-icons
 If you are using a Create React App application
 
 ```js
-import { ReactComponent as MBifold } from "@masonite/svg-icons/dist/svg/bifold.svg";
+import { ReactComponent as MBifold } from '@masonite/svg-icons/dist/svg/bifold.svg'
 ```
 
 or you can import the SVG as a string and implement per your use case or preference.
 
 ```js
-import { mBifold } from "@masonite/svg-icons";
+import { mBifold } from '@masonite/svg-icons'
 ```
+
+## Development
+
+To develop, clone the `Masonitedoors/MDL` repo with `git clone --recurse-submodules -j8` to get it. Make sure MIcons was cloned to `vendors` in its root. You cannot build without it.
+
+## Deployment
+
+1. Make sure you have done what is mentioned in development.
+1. Update the `CHANGELOG.md` for the version you're releasing. If there is an `[Unreleased]` block, change that to the next version following semver.
+1. Build the package `npm run build-package:svg-icons` from the monorepo root, followed by `lerna publish`.


### PR DESCRIPTION
I updated the README for all the packages. I noticed there was nothing on how to get the CSS in the documentation. I know some of us know, considering there's been cross-team collaboration, but I thought it should be explicitly stated so others know as well. I also simplified the main README and moved contributing info to the individual packages. I thought this helps reinforce that the packages do/and can stand on their own. I also removed the manually maintained prop documentation. That'll be handled by TypeScript and/or Storybook soon enough. I didn't think it was worth leaving in half-assed. Anything missing? Anything you want to add?
