### PR TITLE
Remove color from base typography

### DIFF
--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -1,16 +1,14 @@
-@import "colors";
-@import "helpers";
+@import 'colors';
+@import 'helpers';
 
 $base-font-size: 14px;
 
-$font-family: "Gotham SSm A", "Gotham SSm B", -apple-system, BlinkMacSystemFont,
-  "Segoe UI", Helvetica, Arial, sans-serif;
+$font-family: 'Gotham SSm A', 'Gotham SSm B', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+  Helvetica, Arial, sans-serif;
 
 @mixin typography-h1 {
   font-size: 36px;
   margin: 0 0 1rem;
-  color: $color-limerick;
-  font-family: $font-family;
   font-weight: 700;
   line-height: 1.33;
 }
@@ -18,8 +16,6 @@ $font-family: "Gotham SSm A", "Gotham SSm B", -apple-system, BlinkMacSystemFont,
 @mixin typography-h2 {
   font-size: 24px;
   margin: 0 0 1rem;
-  color: $color-m-primary-charcoal;
-  font-family: $font-family;
   font-weight: 700;
   line-height: 1.33;
 }
@@ -27,8 +23,6 @@ $font-family: "Gotham SSm A", "Gotham SSm B", -apple-system, BlinkMacSystemFont,
 @mixin typography-h3 {
   font-size: 18px;
   margin: 0 0 1rem;
-  color: $color-m-primary-charcoal;
-  font-family: $font-family;
   font-weight: 700;
   line-height: 1.39;
 }
@@ -36,8 +30,6 @@ $font-family: "Gotham SSm A", "Gotham SSm B", -apple-system, BlinkMacSystemFont,
 @mixin typography-h4 {
   font-size: 16px;
   margin: 0 0 1rem;
-  color: $color-m-primary-charcoal;
-  font-family: $font-family;
   font-weight: 700;
   line-height: 1.38;
 }
@@ -45,8 +37,6 @@ $font-family: "Gotham SSm A", "Gotham SSm B", -apple-system, BlinkMacSystemFont,
 @mixin typography-h5 {
   font-size: 16px;
   margin: 0 0 1rem;
-  color: $color-m-primary-charcoal;
-  font-family: $font-family;
   font-weight: 400;
   line-height: 1.38;
   text-transform: uppercase;
@@ -55,8 +45,6 @@ $font-family: "Gotham SSm A", "Gotham SSm B", -apple-system, BlinkMacSystemFont,
 @mixin typography-h6 {
   font-size: 12px;
   margin: 0 0 1rem;
-  color: $color-m-primary-charcoal;
-  font-family: $font-family;
   font-weight: 400;
   line-height: 1.42;
   text-transform: uppercase;
@@ -65,8 +53,6 @@ $font-family: "Gotham SSm A", "Gotham SSm B", -apple-system, BlinkMacSystemFont,
 @mixin typography-p {
   font-size: $base-font-size;
   margin: 0 0 1rem;
-  color: $color-m-primary-charcoal;
-  font-family: $font-family;
   line-height: 1.57;
 }
 
@@ -118,10 +104,7 @@ $font-family: "Gotham SSm A", "Gotham SSm B", -apple-system, BlinkMacSystemFont,
     @include typography-p;
   }
 
-  ul li,
-  ol li {
-    @include typography-p;
-
+  li {
     margin: 0 0 1rem;
   }
 

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -8,6 +8,7 @@ body {
   box-sizing: border-box;
   font-family: $font-family;
   font-size: $base-font-size;
+  color: $color-night;
 }
 
 button {


### PR DESCRIPTION
All the default text/headings should be color night (#000) by default. The current colors are dated.

Thoughts on these changes? #126 is pretty old and I didn't want this change to catch anyone off guard. It technically isn't a backwards or breaking change, but if you were relying on the H1 being green by default, you may have to go back and update it, even though there is a good chance it should be black anyways!

---

Fixes #126

I removed font-family as well. It seemed a little over-protective. I think the intention was to fight existing fonts, but if these are used on Masonite properties, what are the odds of a different font? Most websites should not have multiple font faces for their content headings anyways.

Added black text to the html/body root. Possibly overkill.

Edit: I lowered the specificity of the list items because I've had to overwrite them before.