### PR TITLE
Fix webpack mode

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -64,7 +64,7 @@ const resolve = {
 }
 
 module.exports = {
-  mode: 'development',
+  mode: 'production',
   entry: './src/index.js',
   output: {
     filename: 'index.js',

--- a/packages/external-ui-react/CHANGELOG.md
+++ b/packages/external-ui-react/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.29.1] - 2021-01-05
+
+### Fixed
+
+- `/config/webpack.config.js` mode changed from `development` to `production`
+
 ## [2.29.0] - 2020-12-23
 
 ### Added

--- a/packages/external-ui-react/package.json
+++ b/packages/external-ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@masonite/external-ui-react",
-  "version": "2.29.0",
+  "version": "2.29.1",
   "description": "Masonite Design Language for React",
   "main": "dist/index.js",
   "keywords": [],


### PR DESCRIPTION
Fixes https://github.com/masonitedoors/MDL/issues/152

webpack was configured to build for development not production. This caused import issues when using React component library elsewhere.