### PR TITLE
Update Flyout component header

### DIFF
--- a/components/Flyout/react.js
+++ b/components/Flyout/react.js
@@ -9,25 +9,25 @@ import styles from './style.module.scss'
 const cx = classNames.bind(styles)
 
 const Flyout = ({
-  children, onClose, heading, moreHeading, width = 477
-}) => {
-  return (
-    <>
-      <aside className={cx('aside')} style={{ width }}>
-        <div className={cx('header')}>
+  children, onClose, heading, moreHeading, width = 477,
+}) => (
+  <>
+    <aside className={cx('aside')} style={{ width }}>
+      <div className={cx('header')}>
+        <div className={cx('header__left')}>
           <button type="button" onClick={onClose} className={cx('close')}>
             <Icon svg={mX} size={20} />
           </button>
           {heading && <h2>{heading}</h2>}
-          {moreHeading}
         </div>
+        {moreHeading}
+      </div>
 
-        {children}
-      </aside>
-      <ModalBackdrop />
-    </>
-  )
-}
+      {children}
+    </aside>
+    <ModalBackdrop />
+  </>
+)
 
 Flyout.propTypes = {
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,

--- a/components/Flyout/style.module.scss
+++ b/components/Flyout/style.module.scss
@@ -6,17 +6,15 @@
 }
 
 .aside {
+  display: flex;
   position: fixed;
   top: 0;
   right: -100%;
-  height: 100%;
-  background-color: $color-white;
   z-index: 1001;
-
-  animation: slideInCategories ease-out .5s forwards;
-
-  display: flex;
+  height: 100%;
   flex-direction: column;
+  background-color: $color-white;
+  animation: slideInCategories ease-out .5s forwards;
 }
 
 .header {
@@ -24,9 +22,14 @@
   padding: $space-s;
   display: flex;
   align-items: center;
-
+  justify-content: space-between;
+  
   h2 {
     margin-bottom: 0;
+  }
+
+  &__left {
+    display: flex;
   }
 }
 


### PR DESCRIPTION
Separated the left and right side with justify-content, so the action buttons can always be on the right, and the close button is on the left. Thought this could may be done within a project, but the markup needed to be modified.

