### PR TITLE
Fix BulkEdit not passing events properly

### DIFF
--- a/components/BulkEditPopover/react.js
+++ b/components/BulkEditPopover/react.js
@@ -46,8 +46,6 @@ const BulkEditPopover = React.forwardRef(
       return style[popDirection]
     }
 
-    if (formControlProps.onKeyDown) formControlProps.onKeyDown = formControlProps.onKeyDown(value)
-
     switch (formControlType) {
       case TextField:
         formControlProps = {

--- a/components/BulkEditPopover/style.module.scss
+++ b/components/BulkEditPopover/style.module.scss
@@ -5,7 +5,6 @@
   pointer-events: none;
   position: absolute;
   z-index: 10;
-  padding: 2rem;
   background-color: $color-deepgray;
 
   &--visible {


### PR DESCRIPTION
I think the original intent here was to provide the input value on the onKeyDown event since that'd get you just the value of the key pressed, but I'm sure you can get the value still. This was just a convenience fail.

Removed padding. Didn't make sense with any of the existing styles for the form controls.
