### PR TITLE
Add pass-through props to Flyout. Fix ModalBackdrop throwing an error…

### DIFF
--- a/components/Flyout/__snapshots__/react.test.js.snap
+++ b/components/Flyout/__snapshots__/react.test.js.snap
@@ -3,35 +3,39 @@
 exports[`Flyout should render with content 1`] = `
 <DocumentFragment>
   <aside
-    class="aside"
-    style="width: 700px;"
+    class="aside some class-name"
+    style="width: 700px; background-color: rgb(170, 187, 204);"
   >
     <div
       class="header"
     >
-      <button
-        class="close"
-        type="button"
+      <div
+        class="header__left"
       >
-        <div
-          class="icon "
-          style="height: 20px; width: 20px;"
+        <button
+          class="close"
+          type="button"
         >
-          <svg
-            version="1.1"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <div
+            class="icon "
+            style="height: 20px; width: 20px;"
           >
-            <title />
-            <path
-              d="M13.4 12l5.3-5.3c0.4-0.4 0.4-1 0-1.4s-1-0.4-1.4 0l-5.3 5.3-5.3-5.3c-0.4-0.4-1-0.4-1.4 0s-0.4 1 0 1.4l5.3 5.3-5.3 5.3c-0.4 0.4-0.4 1 0 1.4 0.2 0.2 0.4 0.3 0.7 0.3s0.5-0.1 0.7-0.3l5.3-5.3 5.3 5.3c0.2 0.2 0.5 0.3 0.7 0.3s0.5-0.1 0.7-0.3c0.4-0.4 0.4-1 0-1.4l-5.3-5.3z"
-            />
-          </svg>
-        </div>
-      </button>
-      <h2>
-        My heading
-      </h2>
+            <svg
+              version="1.1"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title />
+              <path
+                d="M13.4 12l5.3-5.3c0.4-0.4 0.4-1 0-1.4s-1-0.4-1.4 0l-5.3 5.3-5.3-5.3c-0.4-0.4-1-0.4-1.4 0s-0.4 1 0 1.4l5.3 5.3-5.3 5.3c-0.4 0.4-0.4 1 0 1.4 0.2 0.2 0.4 0.3 0.7 0.3s0.5-0.1 0.7-0.3l5.3-5.3 5.3 5.3c0.2 0.2 0.5 0.3 0.7 0.3s0.5-0.1 0.7-0.3c0.4-0.4 0.4-1 0-1.4l-5.3-5.3z"
+              />
+            </svg>
+          </div>
+        </button>
+        <h2>
+          My heading
+        </h2>
+      </div>
       <button>
         A test button
       </button>
@@ -59,26 +63,30 @@ exports[`Flyout should render without crashing 1`] = `
     <div
       class="header"
     >
-      <button
-        class="close"
-        type="button"
+      <div
+        class="header__left"
       >
-        <div
-          class="icon "
-          style="height: 20px; width: 20px;"
+        <button
+          class="close"
+          type="button"
         >
-          <svg
-            version="1.1"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+          <div
+            class="icon "
+            style="height: 20px; width: 20px;"
           >
-            <title />
-            <path
-              d="M13.4 12l5.3-5.3c0.4-0.4 0.4-1 0-1.4s-1-0.4-1.4 0l-5.3 5.3-5.3-5.3c-0.4-0.4-1-0.4-1.4 0s-0.4 1 0 1.4l5.3 5.3-5.3 5.3c-0.4 0.4-0.4 1 0 1.4 0.2 0.2 0.4 0.3 0.7 0.3s0.5-0.1 0.7-0.3l5.3-5.3 5.3 5.3c0.2 0.2 0.5 0.3 0.7 0.3s0.5-0.1 0.7-0.3c0.4-0.4 0.4-1 0-1.4l-5.3-5.3z"
-            />
-          </svg>
-        </div>
-      </button>
+            <svg
+              version="1.1"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title />
+              <path
+                d="M13.4 12l5.3-5.3c0.4-0.4 0.4-1 0-1.4s-1-0.4-1.4 0l-5.3 5.3-5.3-5.3c-0.4-0.4-1-0.4-1.4 0s-0.4 1 0 1.4l5.3 5.3-5.3 5.3c-0.4 0.4-0.4 1 0 1.4 0.2 0.2 0.4 0.3 0.7 0.3s0.5-0.1 0.7-0.3l5.3-5.3 5.3 5.3c0.2 0.2 0.5 0.3 0.7 0.3s0.5-0.1 0.7-0.3c0.4-0.4 0.4-1 0-1.4l-5.3-5.3z"
+              />
+            </svg>
+          </div>
+        </button>
+      </div>
     </div>
   </aside>
   <div

--- a/components/Flyout/react.js
+++ b/components/Flyout/react.js
@@ -9,10 +9,10 @@ import styles from './style.module.scss'
 const cx = classNames.bind(styles)
 
 const Flyout = React.forwardRef(({
-  children, onClose, heading, moreHeading, width = 477,
+  children, onClose, heading, moreHeading, width = 477, className, style, ...rest
 }, ref) => (
   <>
-    <aside ref={ref} className={cx('aside')} style={{ width }}>
+    <aside ref={ref} className={cx('aside', className)} style={{ width, ...style }} {...rest}>
       <div className={cx('header')}>
         <div className={cx('header__left')}>
           <button type="button" onClick={onClose} className={cx('close')}>
@@ -31,6 +31,7 @@ const Flyout = React.forwardRef(({
 
 Flyout.propTypes = {
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
+  className: PropTypes.string,
   onClose: PropTypes.func.isRequired,
   heading: PropTypes.string,
   moreHeading: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),

--- a/components/Flyout/react.test.js
+++ b/components/Flyout/react.test.js
@@ -16,6 +16,9 @@ describe('Flyout', () => {
         heading="My heading"
         moreHeading={<button>A test button</button>}
         width={700}
+        className="some class-name"
+        style={{ backgroundColor: "#abc" }}
+        onMouseEnter={() => {}}
       >
         <div>Some body content</div>
       </Flyout>

--- a/components/ModalBackdrop/react.js
+++ b/components/ModalBackdrop/react.js
@@ -29,7 +29,7 @@ const ModalBackdrop = ({
         ref={backdropRef}
         className={cx('modal-backdrop', show && 'modal-backdrop--active', className)}
         style={style}
-        onClick={event => event.target === backdropRef.current && onOutsideClick()}
+        onClick={event => event.target === backdropRef.current && onOutsideClick && onOutsideClick()}
       >
         <CSSTransition in={entered} timeout={250} classNames="modal-backdrop__content">
           <div className={cx('modal-backdrop__content')}>{children}</div>
@@ -42,7 +42,7 @@ const ModalBackdrop = ({
 export default ModalBackdrop
 
 ModalBackdrop.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   className: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
   onOutsideClick: PropTypes.func,
   show: PropTypes.bool,


### PR DESCRIPTION
… when onOutsideClick isn't passed.
